### PR TITLE
Fix compiler warnings in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: c
 compiler:
  - clang
@@ -17,7 +19,6 @@ script:
 # Coverity Scan configuration
 env:
   global:
-   - CFLAGS="-Wunused-result -Wno-error=unused-result"
    - secure: "mvZ7LO2lCFicTg+L3c4PvDeXtMR7ez2pfPYJ/BSYLknTx1yzz31p9k1lwFPnG86oBK4A5MxnlGj+LAfLBRR2ZxvVh5enQyjqSSFfGzG06bmSmfzbM+wkveTzFiKyAnWyzd0bFshsU0tuFXU4QH3jiO+/QO+ixybNyw2wgC+yBz0/OBmzIVKvoK7mqBl31givL6YsLPF5HdipMZK7KHYxp1Kjj36AF1QmsivMKalMjBGIh5PeJ8QY3R/GDdy+I2zEyAS1a6fFMcBbCQrjPl4eQJ/y6pl3EuvMfeSjRUPXvzEf9fiwZcuiw9KY0EDtYuIAyzaBUTHuW/tO359LbLYI4X2V3SgA5b58H0zDvavssRzAp/l/bYq70Q0n1Xz/aF1R01SDqG48BFMWWT3eb7eLIeZNapPLOWk07D801Wpt8XYbfEDZZ5FA5UK/o8DBAlIEDivFLkuG2+vv9wMwY0qkTQ8ZyBvfSRa/pjVBpiPiPRO5Pg6UrnPOHnX7hf+IGa1U38vY8S8sBdA0Xc4QSH3K7dQZc33N12Nhrbp9hQR5WFPz35CZVnf77XPLSWocG1icb6tFF2ybzE26XiUXzRy6eaVkfcNlAvtUl4Rci7520436bJnNfZiFMD9Lj4Wy/td89guqboH2jETcHbly5h5yqfL+95pCt+0i3zCtC0GfrbU="
 addons:
   coverity_scan:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
 # Coverity Scan configuration
 env:
   global:
+   - CFLAGS="-Wno-unused-result"
    - secure: "mvZ7LO2lCFicTg+L3c4PvDeXtMR7ez2pfPYJ/BSYLknTx1yzz31p9k1lwFPnG86oBK4A5MxnlGj+LAfLBRR2ZxvVh5enQyjqSSFfGzG06bmSmfzbM+wkveTzFiKyAnWyzd0bFshsU0tuFXU4QH3jiO+/QO+ixybNyw2wgC+yBz0/OBmzIVKvoK7mqBl31givL6YsLPF5HdipMZK7KHYxp1Kjj36AF1QmsivMKalMjBGIh5PeJ8QY3R/GDdy+I2zEyAS1a6fFMcBbCQrjPl4eQJ/y6pl3EuvMfeSjRUPXvzEf9fiwZcuiw9KY0EDtYuIAyzaBUTHuW/tO359LbLYI4X2V3SgA5b58H0zDvavssRzAp/l/bYq70Q0n1Xz/aF1R01SDqG48BFMWWT3eb7eLIeZNapPLOWk07D801Wpt8XYbfEDZZ5FA5UK/o8DBAlIEDivFLkuG2+vv9wMwY0qkTQ8ZyBvfSRa/pjVBpiPiPRO5Pg6UrnPOHnX7hf+IGa1U38vY8S8sBdA0Xc4QSH3K7dQZc33N12Nhrbp9hQR5WFPz35CZVnf77XPLSWocG1icb6tFF2ybzE26XiUXzRy6eaVkfcNlAvtUl4Rci7520436bJnNfZiFMD9Lj4Wy/td89guqboH2jETcHbly5h5yqfL+95pCt+0i3zCtC0GfrbU="
 addons:
   coverity_scan:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
 # Coverity Scan configuration
 env:
   global:
+   - CFLAGS="-Wunused-result -Wno-error=unused-result"
    - secure: "mvZ7LO2lCFicTg+L3c4PvDeXtMR7ez2pfPYJ/BSYLknTx1yzz31p9k1lwFPnG86oBK4A5MxnlGj+LAfLBRR2ZxvVh5enQyjqSSFfGzG06bmSmfzbM+wkveTzFiKyAnWyzd0bFshsU0tuFXU4QH3jiO+/QO+ixybNyw2wgC+yBz0/OBmzIVKvoK7mqBl31givL6YsLPF5HdipMZK7KHYxp1Kjj36AF1QmsivMKalMjBGIh5PeJ8QY3R/GDdy+I2zEyAS1a6fFMcBbCQrjPl4eQJ/y6pl3EuvMfeSjRUPXvzEf9fiwZcuiw9KY0EDtYuIAyzaBUTHuW/tO359LbLYI4X2V3SgA5b58H0zDvavssRzAp/l/bYq70Q0n1Xz/aF1R01SDqG48BFMWWT3eb7eLIeZNapPLOWk07D801Wpt8XYbfEDZZ5FA5UK/o8DBAlIEDivFLkuG2+vv9wMwY0qkTQ8ZyBvfSRa/pjVBpiPiPRO5Pg6UrnPOHnX7hf+IGa1U38vY8S8sBdA0Xc4QSH3K7dQZc33N12Nhrbp9hQR5WFPz35CZVnf77XPLSWocG1icb6tFF2ybzE26XiUXzRy6eaVkfcNlAvtUl4Rci7520436bJnNfZiFMD9Lj4Wy/td89guqboH2jETcHbly5h5yqfL+95pCt+0i3zCtC0GfrbU="
 addons:
   coverity_scan:

--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,7 @@ AM_CONDITIONAL([RSAREF_TESTS], [test x"enable_rsaref_tests" = x"yes"])
 AC_ARG_ENABLE([developer-warnings],
     AS_HELP_STRING([--enable-developer-warnings],
 	[enable strict warnings (default is NO)]),
-    [CFLAGS="${CFLAGS} -Wall -Wextra -Wcast-qual -Wshadow -Wno-unused-result"])
+    [CFLAGS="${CFLAGS} -Wall -Wextra -Wcast-qual -Wshadow"])
 AC_ARG_ENABLE([debugging-symbols],
     AS_HELP_STRING([--enable-debugging-symbols],
 	[enable debugging symbols (default is NO)]),

--- a/lib/test/cryb_t_main.c
+++ b/lib/test/cryb_t_main.c
@@ -139,7 +139,8 @@ t_add_test(t_func *func, void *arg, const char *fmt, ...)
 		err(1, "malloc()");
 	t->func = func;
 	va_start(ap, fmt);
-	(void)vasprintf(&t->desc, fmt, ap);
+	if (vasprintf(&t->desc, fmt, ap) < 0)
+		err(1, "vasprintf()");
 	va_end(ap);
 	t->arg = arg;
 	t_grow(1);


### PR DESCRIPTION
Travis forces _FORTIFY_SOURCE, which enables __warn_unused_result__ annotations in glibc.  Some of those annotations are of dubious value; in the case of asprintf(3) and vasprintf(3), they flag code that doesn't check the return value as unsafe even if it checks the pointer instead (which is guaranteed to be NULL in case of failure, and arguably more useful than the return value). Unfortunately, gcc [intentionally ignores (void) casts](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425), so we have no choice but to quench the warning with `-Wno-unused-result`. However, some of the compilers we wish to support don't recognize it, so we move it from the developer flags to the Travis environment.

While there, switch Travis from Precious to Trusty.