### PR TITLE
Fix double-NULL case.

### DIFF
--- a/lib/test/cryb_t_compare.c
+++ b/lib/test/cryb_t_compare.c
@@ -110,7 +110,8 @@ t_compare_mem(const void *expected, const void *received, size_t len)
 		t_printv("\n");
 		t_printv("received null pointer\n");
 		return (0);
-	} else if (memcmp(expected, received, len) != 0) {
+	} else if (expected != NULL && received != NULL &&
+	    memcmp(expected, received, len) != 0) {
 		t_printv("expected ");
 		t_printv_hex(expected, len);
 		t_printv("\n");
@@ -137,7 +138,8 @@ t_compare_str(const char *expected, const char *received)
 		t_printv("expected \"%s\"\n", expected);
 		t_printv("received null pointer\n");
 		return (0);
-	} else if (strcmp(expected, received) != 0) {
+	} else if (expected != NULL && received != NULL &&
+	    strcmp(expected, received) != 0) {
 		t_printv("expected %s\n", expected);
 		t_printv("received %s\n", received);
 		return (0);


### PR DESCRIPTION
Fix null pointer dereference in t_compare_mem() and t_compare_str() when both the expected value and the received value are NULL.